### PR TITLE
Updated Dockerfile removed old hacks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM ubuntu:14.04
 MAINTAINER sameer@damagehead.com
 
-RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
- && echo 'APT::Install-Suggests 0;' >> /etc/apt/apt.conf.d/01norecommends \
- && apt-get update \
+RUN apt-get update \
  && apt-get install -y vim.tiny wget sudo net-tools ca-certificates \
  && rm -rf /var/lib/apt/lists/* # 20141218


### PR DESCRIPTION
The hacks arn't needed any more ubuntu fixed it in its apt-get as also docker applyed some to the base ubuntu image that your using. You get now better results without that i think it will not brake any existing img i am near 100% sure!